### PR TITLE
added env needed for google analytics to work as intended

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,6 +42,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
+      JEKYLL_ENV: production
     runs-on: ubuntu-latest
     needs: build
     steps:


### PR DESCRIPTION
According to https://github.com/mmistakes/jekyll-theme-basically-basic/tree/master#google-analytics, an environment variable 
`JEKYLL_ENV` needs to be set to `production` for google analytics to work. This, combined with verifying the value in the `_config.yml` should solve issue #15 