### PR TITLE
Add past-exams redirect from navbar

### DIFF
--- a/_data/theme.yml
+++ b/_data/theme.yml
@@ -3,6 +3,7 @@ skin: night # default, night, plum, sea, soft, steel
 navigation_pages:
   - join_skip.md
   - membership.md
+  - past_exams.md
   - posts.md
 
 t:

--- a/past_exams.md
+++ b/past_exams.md
@@ -1,0 +1,16 @@
+---
+title: Past Exams
+layout: post
+permalink: /past-exams/
+actions:
+  - label: "View Repository"
+    icon: github
+    url: "https://skipgu.org/past-exams/"
+---
+
+<!-- This is just a fallback page, the subpage ./past-exams/ is a stand-alone
+  subpage. Hence, this page will only be displayed in case the subpage is
+  temporarily disabled. -->
+
+Feel free to explore, contribute, and make the most of this repository as you
+strive for excellence in your studies!


### PR DESCRIPTION
## Add 'past-exams' redirect from navbar

The navbar contains another item, *'past-exams'*, which redirects the user $\to$ [`https://skipgu.org/past-exams/`](https://skipgu.org/past-exams/).

Resolves #36.