### PR TITLE
Swap masthead logo and menu positions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,4 @@ end
 
 gem "webrick"
 gem "rexml"
+gem 'csv'

--- a/assets/stylesheets/main.scss
+++ b/assets/stylesheets/main.scss
@@ -1,0 +1,29 @@
+---
+# Override basically-basic theme styling
+---
+
+@import "basically-basic/themes/{{ site.data.theme.skin | default: 'default' }}";
+@import "basically-basic";
+
+.sidebar-toggle-wrapper {
+  left: 0;
+  right: auto;
+  padding-left: 1rem;
+  transition: left 0.8s ease;
+  background-color: transparent;
+
+  .navicon-button {
+    
+    &.open {
+      position: fixed;
+      left: $sidebar-width;
+      padding-left: 1.5rem;
+      transition: all 0.8s ease;
+      top: 1.8125rem;
+      
+      @include breakpoint($large) {
+        left: 1.5 * $sidebar-width;
+      }
+    }
+  }
+}

--- a/assets/stylesheets/main.scss
+++ b/assets/stylesheets/main.scss
@@ -8,7 +8,7 @@
 .sidebar-toggle-wrapper {
   left: 0;
   right: auto;
-  padding-left: 1rem;
+  padding-left: 2rem;
   transition: left 0.8s ease;
   background-color: transparent;
 
@@ -26,4 +26,13 @@
       }
     }
   }
+}
+
+#masthead {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.site-title {
+  padding-right: 2rem;
 }


### PR DESCRIPTION
## Overview
Currently, the website masthead has the logo on the left side, and the hamburger menu on the right side. This is the default styling from the [basically-basic](https://github.com/mmistakes/jekyll-theme-basically-basic) theme that the website is built with. In order to apply custom styling, the `main.scss` file that the remote theme provides needs to be overridden.

## Changes
* Create custom `main.scss` file that overrides the default proved by basically-basic.
* Swap places with the hamburger menu icon and the SKIP logo in the masthead.

## Result


https://github.com/user-attachments/assets/01c1a6bf-6650-46e8-b12d-35c6993c1b81



## Additional notes
* The changes have also made the menu more responsive to mobile devices.
* With this change, the masthead logo goes "out of bounds" when opening the menu. There was an attempt to dynamically move it when opening the menu, but it proved to be difficult while ensuring responsiveness.
* The gem `csv` was added to the Gemfile, since it was moved out of the default gems in Ruby 3.4.0. Since this gem is necessary for the `jekyll serve` command, the gem is explicitly added to support Ruby versions >= 3.4.0

Closes #32