### PR TITLE
Fix Broken Pipeline (#52)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v5
       - name: Build with Jekyll
         uses: actions/jekyll-build-pages@v1
         with:
@@ -36,7 +36,7 @@ jobs:
           destination: ./_site
           future: true
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
 
   # Deployment job
   deploy:
@@ -50,5 +50,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
-
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Updated deprecated GitHub Actions to fix broken pipeline:
- `actions/upload-pages-artifact` from v2 to v3
- `actions/deploy-pages` from v2 to v4
- `actions/configure-pages` from v3 to v5