### PR TITLE
Move social links to footer

### DIFF
--- a/_includes/footer-social-list.html
+++ b/_includes/footer-social-list.html
@@ -1,0 +1,35 @@
+<ul class="footer-social-list">
+  {% if site.instagram_username %}
+    <li>{% include icon-instagram.html username=site.instagram_username label='Instagram' %}</li>
+  {% endif %}
+
+  {% if site.discord_link %}
+    <li>{% include icon-discord.html link=site.discord_link label='Discord' %}</li>
+  {% endif %}
+
+  {% if site.linkedin_username %}
+    <li>{% include icon-linkedin.html username=site.linkedin_username label='LinkedIn' %}</li>
+  {% endif %}
+
+  {% if site.github_username %}
+    <li>{% include icon-github.html username=site.github_username label='GitHub' %}</li>
+  {% endif %}
+
+  {% if site.email %}
+    <li>
+      <a href="mailto:{{ site.email }}">
+        <span class="icon icon--email">{% include icon-email.svg %}</span>
+        <span class="label">{{ site.data.theme.t.email | default: 'Email' }}</span>
+      </a>
+    </li>
+  {% endif %}
+
+  <li>
+    {% if site.plugins contains 'jekyll-feed' or site.gems contains 'jekyll-feed' %}
+      <a href="{{ site.feed.path | default: 'feed.xml' | relative_url }}" title="Atom Feed">
+        <span class="icon icon--rss">{% include icon-rss.svg %}</span>
+        <span class="label">{{ site.data.theme.t.subscribe | default: 'Subscribe' }}</span>
+      </a>
+    {% endif %}
+  </li>
+</ul>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,0 +1,13 @@
+<footer id="footer" class="site-footer">
+  <div class="inner">
+    <div class="copyright">
+      {% if site.copyright %}
+        {{ site.copyright | markdownify }}
+      {% else %}
+        <p>&copy; {{ site.time | date: '%Y' }} {{ site.title }}.</p>
+      {% endif %}
+    </div>
+
+    {% include footer-social-list.html %}
+  </div>
+</footer>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<!--
+    Basically Basic Jekyll Theme 1.4.5
+    Copyright 2017-2018 Michael Rose - mademistakes.com | @mmistakes
+    Free for personal and commercial use under the MIT license
+    https://github.com/mmistakes/jekyll-theme-basically-basic/blob/master/LICENSE
+-->
+<html lang="{{ page.lang | default: site.lang | default: 'en-US' }}" class="no-js">
+  {% include head.html %}
+
+  <body class="layout--{{ page.layout | default: layout.layout }}{% if page.classes or layout.classes %}{{ page.classes | default: layout.classes | join: ' ' | prepend: ' ' }}{% endif %} {{ page.title | slugify }}">
+
+    {% include skip-links.html %}
+
+    <div class="sidebar-toggle-wrapper">
+      {% if site.search %}
+        <button class="search-toggle" type="button">
+          <svg class="icon" width="16" height="16" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 15.99 16">
+            <title>{{ site.data.theme.t.search | default: 'Search' }}</title>
+            <path d="M15.5,13.12L13.19,10.8a1.69,1.69,0,0,0-1.28-.55l-0.06-.06A6.5,6.5,0,0,0,5.77,0,6.5,6.5,0,0,0,2.46,11.59a6.47,6.47,0,0,0,7.74.26l0.05,0.05a1.65,1.65,0,0,0,.5,1.24l2.38,2.38A1.68,1.68,0,0,0,15.5,13.12ZM6.4,2A4.41,4.41,0,1,1,2,6.4,4.43,4.43,0,0,1,6.4,2Z" transform="translate(-.01)"></path>
+          </svg>
+        </button>
+      {% endif %}
+
+      <button class="toggle navicon-button larr" type="button">
+        <span class="toggle-inner">
+          <span class="sidebar-toggle-label visually-hidden">{{ site.data.theme.t.menu | default: 'Menu' }}</span>
+          <span class="navicon"></span>
+        </span>
+      </button>
+    </div>
+
+    <div id="sidebar" class="sidebar">
+      <div class="inner">
+        {% include navigation.html %}
+      </div>
+    </div>
+
+    <div class="canvas">
+      <div class="wrapper">
+        {% include masthead.html %}
+        <div class="initial-content">
+          {{ content }}
+        </div>
+
+        <div class="search-content">
+          {% include search-form.html %}
+        </div>
+      </div>
+    </div>
+
+    {% include footer.html %}
+    {% include scripts.html %}
+
+  </body>
+
+</html>

--- a/assets/stylesheets/main.scss
+++ b/assets/stylesheets/main.scss
@@ -36,3 +36,79 @@
 .site-title {
   padding-right: 2rem;
 }
+.site-footer {
+  .inner {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    max-width: $main-max-width;
+    margin: 0 auto;
+    padding: 1.5rem 0.5rem;
+
+    @include breakpoint($small) {
+      padding-right: 1rem;
+      padding-left: 1rem;
+    }
+
+    @include breakpoint($medium) {
+      padding-right: 2rem;
+      padding-left: 2rem;
+    }
+
+    @include breakpoint($large) {
+      padding-right: 3rem;
+      padding-left: 3rem;
+    }
+
+    @include breakpoint($xlarge) {
+      padding-right: 4rem;
+      padding-left: 4rem;
+    }
+
+    @media (max-width: $medium) {
+      flex-direction: column;
+      text-align: center;
+    }
+  }
+
+  .copyright {
+    margin: 0;
+
+    p {
+      margin: 0;
+    }
+  }
+}
+
+.footer-social-list {
+  @include list-unstyled;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 1.5rem;
+  margin: 0;
+
+  a {
+    display: inline-flex;
+    align-items: center;
+    color: inherit;
+    text-decoration: none;
+
+    &:hover,
+    &:focus {
+      color: $accent-color;
+      text-decoration: none;
+    }
+  }
+
+  .icon {
+    margin-right: 0.25em;
+  }
+
+  li:empty {
+    display: none;
+  }
+}


### PR DESCRIPTION
## Description
Moves the social media links (Instagram, Discord, LinkedIn, GitHub, Email) from the sidebar burger menu into a new site footer, alongside the copyright notice. This gives the site a standard footer layout instead of the markdown-list style in the sidebar.

Closes #70

## Changes
- Add `_includes/footer-social-list.html`: new partial rendering social/contact links for the footer
- Override `_includes/footer.html` to render the social links alongside the copyright
- Override `_layouts/default.html` (from the `basically-basic` remote theme) to remove the sidebar's contact list include
- Update `assets/stylesheets/main.scss`: style the footer as a two-column row (copyright left, links right), remove link underline/color styling, add padding and width constraints to match the page content

## Testing
- [x] Verified locally with `./scripts/dev.sh`
- [x] Confirmed sidebar no longer shows social links
- [x] Confirmed footer renders on multiple pages (home, post, static page) with correct spacing on desktop and mobile widths