### PR TITLE
Fix navbar style on desktop

### DIFF
--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -38,8 +38,14 @@
             left: 0;
           }
 
-          .nav-bar {
-            gap: 1.5rem;
+          .nav-bar a {
+            padding: 0.5rem 0.7rem;
+            color: #ffffff;
+            text-decoration: none;
+          }
+
+          .nav-bar a:hover {
+            border-bottom: 0.2rem solid rgb(224, 91, 91);
           }
 
           .canvas {

--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -13,6 +13,24 @@
             .sidebar-toggle-wrapper { display: block; }
             #sidebar { display: block; } 
         }
+
+        /*Fix the nav bar on desktop */
+        @media (min-width: 769px) {
+          #masthead {
+              position: sticky;
+              top: 0;
+              z-index: 1000;
+          }
+
+          .canvas {
+            overflow: visible;
+          }
+
+          .wrapper {
+              transform: none;
+          }
+        }
+
     </style>
     
   <div class="inner"

--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -20,6 +20,26 @@
               position: sticky;
               top: 0;
               z-index: 1000;
+              background-color: #12151f; /*darker than bg version 1*/
+              box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
+          }
+
+          #masthead .site-logo {
+            height: 32px;   
+            width: auto;
+          }
+
+          #masthead .inner {
+            display: flex; 
+            align-items: center; 
+            justify-content: space-between;
+            font-size: 1rem;
+            height: 3.5rem;
+            left: 0;
+          }
+
+          .nav-bar {
+            gap: 1.5rem;
           }
 
           .canvas {
@@ -33,13 +53,8 @@
 
     </style>
     
-  <div class="inner"
-    style="display: flex; align-items: center; justify-content: space-between;"
-  >
-
-    <nav class="nav-bar" 
-        style="gap: 1.5rem;"
-    >
+  <div class="inner">
+    <nav class="nav-bar">
       <!--Home link-->
       <a href="{{ '/' | relative_url }}" itemprop="url">
         <span itemprop="name">{{ site.data.theme.t.home | default: 'Home' }}</span>

--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -40,7 +40,7 @@
 
           .nav-bar a {
             padding: 0.5rem 0.7rem;
-            color: #ffffff;
+            color: #f3f3f3;
             text-decoration: none;
           }
 


### PR DESCRIPTION
# Changes made:
- Fixed the nav bar on top of the screen when scrolling
- Made the background of the nav bar darker
- Removed text underlines on the links and changed colour to solid white (from turquoise)
- Added bottom border to the links when hovering over them
- Increased font size of the links

Closes #82 